### PR TITLE
Add alternate morphing functions to prompt-morph.

### DIFF
--- a/prompt_morph.py
+++ b/prompt_morph.py
@@ -26,7 +26,7 @@ F_LINEAR = "Linear"
 F_SINE = "Sine (slow, fast, slow)"
 F_HALF_PARABOLIC = "S-Parabola (fast, slow, fast)"
 F_PARABOLIC = "Parabolic (slow, fast, faster)"
-F_PARABOLIC_BOUNCE = "Parabolic Bounce (slow, fast, faster, faster, fast, slow)"
+F_PARABOLIC_BOUNCE = "Parabolic Bounce (parabola, reverse every other keyframe)"
 
 MORPH_FUNCTIONS = [
     F_LINEAR,
@@ -172,25 +172,25 @@ class Script(scripts.Script):
 
         if (morph_func == F_LINEAR):
             # 0 to 1
-            t = pct
+            t = x
         elif (morph_func == F_SINE):
             # 0 is 1 and pi is -1 - sort of an s-shape
-            pct_pi = math.pi * pct
-            t = 0.5 - (0.5*math.cos(pct_pi))
+            x_pi = math.pi * x
+            t = 0.5 - (0.5*math.cos(x_pi))
         elif (morph_func == F_HALF_PARABOLIC):
             # a parabola where the left half is flipped down
-            t = ((((2 * pct) - 1) * abs((2 * pct) - 1)) / 2) + 0.5
+            t = ((((2 * x) - 1) * abs((2 * x) - 1)) / 2) + 0.5
         elif (morph_func == F_PARABOLIC):
             # accelerate
-            t = pct**2
+            t = x**2
         elif (morph_func == F_PARABOLIC_BOUNCE):
             # Alternate between accelerating and decelerating
             if (n % 2 == 1):
-                t = pct**2
+                t = x**2
             else:
-                t = 1 - ((1 - pct)**2)
+                t = 1 - ((1 - x)**2)
         else:
             # default to linear
             print ("Morph Function " + morph_func + " not recognized. Using " + F_LINEAR + " instead.")
-            t = pct
+            t = x0
         return t


### PR DESCRIPTION
# Overview

`prompt_morph.py` currently always morphs between each prompt in a linear way.  This PR adds some alternate morphing functions in order to spend more/less time at keyframes, depending on the user's preference.

# Comparison

Here is a series of gifs illustrating the difference.  The gifs are stuck together so that the keyframes should always synchronize.  The circle and square are the keyframes, the hands (?) generally appear in the middle.  

`A (red circle|blue square), viewed from the side. Clip art. Steps: 28, Sampler: Euler a, CFG scale: 28.5, Seed: 713180077`

![morphin-time](https://user-images.githubusercontent.com/299084/201503535-1cbbf26d-afa4-489e-b849-f9519ec6148c.gif)

*From left-to-right: Linear, Sine, S-Parabola, Parabolic, Parabolic Bounce*

# x/y graphs

## Linear

This is the current behavior.

<img src="https://user-images.githubusercontent.com/299084/201503287-ee9ace93-f1f7-46ea-aa79-e370a3925096.png" alt="linear" width=200/>

## Sine (but secretly Cosine)

Start slow, speed through the middle, then slow again.  The difference from `Linear` is barely noticeable, though.

<img src="https://user-images.githubusercontent.com/299084/201503289-97784bc8-4d17-401d-92f8-befcf734dc7e.png" alt="sine" width=200 />

## S-parabola

Start and end fast, linger in the middle for a bit.  NOTE: I am pretty sure there is a proper mathematical name for this, but I don't know it.

<img src="https://user-images.githubusercontent.com/299084/201503290-77898c8a-6284-42ba-8a98-ef480e6c15cb.png" alt="S-Parabola" width=200 />

## Parabolic

Start slow and accelerate.  Drop back to zero velocity on every keyframe.

<img src="https://user-images.githubusercontent.com/299084/201503292-c3309a31-5fbd-4bdf-b4a5-1d2be17496c9.png" alt="parabolic" width=200 />

## Parabola bounce

Alternate between accelerating and decelerating.  If `linear` would cause a ball to move up-down-up at steady velocity, `Parabola bounce` would cause it to look like it was bouncing off the ground like a normal ball affected by gravity.  In the gifs above, you can see that (4) and (5) are identical from circle to square, but then differ on the subsequent morph.

<img src="https://user-images.githubusercontent.com/299084/201503293-c7daf1eb-4c21-40c7-bb05-c99a0f93a1e4.png" alt="Parabolic bounce" width=200 />

# Discussion / Rationale

* My theory was that if there was a morph where e.g. a basketball went from someone's hand to the ground, the parabolic bounce would allow it to better simulate gravity.  But then it turned out I couldn't find any sort of prompt pair to generate that kind of behavior.
* Another use case was for animating body movement.  `person with arms up` -> `person with arms down`.  The morphs didn't produce expected movement though.
* I guess my question is, the original rationale behind this PR didn't pan out as expected, but is the functionality still useful?

# Future work

* I liked the idea of the `Sine` function spending more time near the keyframes, and "glossing over" the chaotic parts between keyframes.  But it's hardly noticeable.  Perhaps I'll revisit this to find a better function to meet that criteria.
* On the other hand, maybe we should scrap the dropdown entirely, and support the complex inline math that `Deforum` uses?

# Also also wik

* A line starting with `#` will be treated as a comment, and ignored.